### PR TITLE
Change the name of a tablename and the figurename to Japanese

### DIFF
--- a/jsise.sty
+++ b/jsise.sty
@@ -11,6 +11,8 @@
 \setlength{\abstractwidth}{15cm}
 
 \renewcommand{\baselinestretch}{1.0}
+\renewcommand{\figurename}{図}
+\renewcommand{\tablename}{表}
 
 \pagestyle{empty}
 \thispagestyle{empty}


### PR DESCRIPTION
## 概要
図と表のタイトルが英語であったので、研究会報告の見本に合わせて日本語に変更した
## 変更点
jsise.styに
```
\renewcommand{\figurename}{図}
\renewcommand{\tablename}{表}


```
を追加した