### PR TITLE
changed the cite from normal character to superscript

### DIFF
--- a/jsise.sty
+++ b/jsise.sty
@@ -60,3 +60,8 @@
 
 \twocolumn
 \setlength{\columnsep}{28pt}
+
+\bibliographystyle{jplain}
+\makeatletter
+\def\@biblabel#1{(#1)}
+\renewcommand{\@cite}[1]{\textsuperscript{(#1)}}


### PR DESCRIPTION
## 概要
教育システム情報学会の要項に合わせて、引用の形式を変更。
[]ではなく、()を使用し、上付き文字とした。